### PR TITLE
Switch to using Rich Data and assigning and storing test data based on Job.java rather than Mail.java

### DIFF
--- a/MailMicroservice/src/main/java/dev/sid/mailmicroservice/Kafka/KafkaListener.java
+++ b/MailMicroservice/src/main/java/dev/sid/mailmicroservice/Kafka/KafkaListener.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 @Component
 public class KafkaListener {
 
@@ -55,6 +54,32 @@ public class KafkaListener {
         String email = jsonNode.get("email").asText();
         String id = jsonNode.get("id").asText();
         sendEmailService.sendEmail(email, "Please use this link to give Round-1 of the test http://localhost:5000/round1/"+ id , "Invitation to Interview Round 1");
+    }
+
+    @org.springframework.kafka.annotation.KafkaListener(topics="richOralTestTopic", groupId = "groupId")
+    public void listenerRichSidOralTestLink(String message) throws JsonProcessingException {
+        System.out.println("Listener received for richOralTest "+message);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(message);
+
+        String email = jsonNode.get("email").asText();
+        String id = jsonNode.get("id").asText();
+        String jobId = jsonNode.get("jobId").asText();
+        sendEmailService.sendEmail(email, "Congratulations on clearing Round-1. Please use this link to give Round 2 of the test http://localhost:5174/richRound2/"+ jobId , "Invitation to Interview Round 2");
+    }
+
+    @org.springframework.kafka.annotation.KafkaListener(topics="richTechnicalTestTopic", groupId = "groupId")
+    public void listenerRichKrishTechnicalTestLink(String message) throws JsonProcessingException {
+        System.out.println("Listener received for richTechnicalTest "+message);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(message);
+
+        String email = jsonNode.get("email").asText();
+        String id = jsonNode.get("id").asText();
+        String jobId = jsonNode.get("jobId").asText();
+        sendEmailService.sendEmail(email, "Please use this link to give Round 1  http://localhost:5000/round1/"+ jobId , "Invitation to Interview Round 1");
     }
 
 

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Controller/JobController.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Controller/JobController.java
@@ -2,13 +2,14 @@ package dev.sid.sidspringbackend.Controller;
 
 import dev.sid.sidspringbackend.DTOs.CandidateRankJobAddRequestDTO;
 import dev.sid.sidspringbackend.Model.Job;
+import dev.sid.sidspringbackend.POJOs.OralTestResults;
+import dev.sid.sidspringbackend.Repository.JobRepository;
 import dev.sid.sidspringbackend.Service.JobService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @RestController
 @CrossOrigin(origins = "*")
@@ -49,5 +50,58 @@ public class JobController {
         Optional<Job> job =  jobService.addCandidatesToJob(candidateRankJobAddRequestDTO.getCandidateRankList(), candidateRankJobAddRequestDTO.getHumanReadableJobId());
         return job.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
-}
+
+    @GetMapping("/nextPhase/phase1Dummy")
+    public ResponseEntity<List<Map<String, Object>>>  phase1Handle() {
+        // List to store the candidates
+        List<Map<String, Object>> candidates = new ArrayList<>();
+
+        // Candidate 1
+        Map<String, Object> candidate1 = new HashMap<>();
+        candidate1.put("score", 99);
+        candidate1.put("email", "siddanth.manoj@gmail.com");
+        candidate1.put("summary", "Experienced software developer with expertise in Java.");
+
+        // Candidate 2
+        Map<String, Object> candidate2 = new HashMap<>();
+        candidate2.put("score", 93);
+        candidate2.put("email", "krishmanghani@gmail.com");
+        candidate2.put("summary", "Skilled in front-end development with React and JavaScript. Great Work experience");
+
+        // Candidate 3
+        Map<String, Object> candidate3 = new HashMap<>();
+        candidate3.put("score", 95);
+        candidate3.put("email", "sawant.tanishqa@gmail.com");
+        candidate3.put("summary", "Data scientist with a strong background in machine learning. Over 15 Years of Experience");
+
+        // Adding candidates to the list
+        candidates.add(candidate1);
+        candidates.add(candidate2);
+        candidates.add(candidate3);
+
+        // Return the list of candidates, which will be automatically converted to JSON
+        return ResponseEntity.ok(candidates);
+    }
+
+    @PostMapping("/rich/update-answers")
+    public ResponseEntity<String> richUpdateAnswers(
+            @RequestBody Map<String, Object> requestPayload) {
+
+        // Extract values from the request payload
+        String email = (String) requestPayload.get("name");
+        Map<String, String> questions = (Map<String, String>) requestPayload.get("questions");
+        Map<String, String> answers = (Map<String, String>) requestPayload.get("answers");
+        String jobId = (String) requestPayload.get("jobId");
+
+        // Call the service method to update or create the OralTestResult
+        String resultMessage = jobService.updateOrCreateOralTestResult(email, questions, answers, jobId);
+
+        // Return the appropriate response
+        if ("Job not found".equals(resultMessage)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(resultMessage);
+        } else {
+            return ResponseEntity.ok(resultMessage);
+        }
+    }
+ }
 

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/KafkaProducerConfig.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/KafkaProducerConfig.java
@@ -37,4 +37,14 @@ public class KafkaProducerConfig {
         return new KafkaTemplate<>(producerFactory());
     }
 
+    @Bean
+    public ProducerFactory<String, RichMessageRequest> richProducerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfig());
+    }
+
+    @Bean
+    public KafkaTemplate<String, RichMessageRequest> richKafkaTemplate() {
+        return new KafkaTemplate<>(richProducerFactory());
+    }
+
 }

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/KafkaTopicConfig.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/KafkaTopicConfig.java
@@ -17,4 +17,14 @@ public class KafkaTopicConfig {
     public NewTopic technicalTestTopic() {
         return TopicBuilder.name("technicalTestTopic").build();
     }
+
+    @Bean
+    public NewTopic richOralTestTopic() {
+        return TopicBuilder.name("richOralTestTopic").build();
+    }
+
+    @Bean
+    public NewTopic richTechnicalTopic() {
+        return TopicBuilder.name("richTechnicalTestTopic").build();
+    }
 }

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/NewKafkaJobMailController.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/NewKafkaJobMailController.java
@@ -1,0 +1,53 @@
+package dev.sid.sidspringbackend.Kafka;
+
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("api/v1")
+public class NewKafkaJobMailController {
+    public NewKafkaJobMailController(KafkaTemplate<String, RichMessageRequest> kafkaTemplate) {
+        this.richKafkaTemplate = kafkaTemplate;
+    }
+
+    private KafkaTemplate<String, RichMessageRequest> richKafkaTemplate;
+
+    @PostMapping("/rich/sendSingleTestLink/oralRound2")
+    public void publishSingleOral (@RequestBody RichMessageRequest richMessageRequest) {
+        richKafkaTemplate.send("richOralTestTopic", richMessageRequest);
+        System.out.println("At producer currently "+ richMessageRequest.toString()
+        );
+    }
+
+    @PostMapping("rich/sendMultipleTestLink/oralRound2")
+    public void publishMultipleOral (@RequestBody List<RichMessageRequest> richMessageRequest) {
+//        kafkaTemplate.send("oralTestTopic", messageRequest);
+        for (RichMessageRequest message : richMessageRequest) {
+            richKafkaTemplate.send("richOralTestTopic", message);
+
+            System.out.println("At producer currently "+ message.toString());
+        }
+    }
+
+    @PostMapping("/rich/sendSingleTestLink/technicalRound1")
+    public void publishSingleTechnical (@RequestBody RichMessageRequest richMessageRequest) {
+        richKafkaTemplate.send("richTechnicalTestTopic", richMessageRequest);
+        System.out.println("At producer currently "+ richMessageRequest.toString()
+        );
+    }
+
+    @PostMapping("rich/sendMultipleTestLink/technicalRound1")
+    public void publishMultipleTechnical (@RequestBody List<RichMessageRequest> richMessageRequest) {
+//        kafkaTemplate.send("oralTestTopic", messageRequest);
+        for (RichMessageRequest message : richMessageRequest) {
+            richKafkaTemplate.send("richTechnicalTestTopic", message);
+
+            System.out.println("At producer currently "+ message.toString());
+        }
+    }
+
+}

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/RichMessageRequest.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Kafka/RichMessageRequest.java
@@ -1,0 +1,6 @@
+package dev.sid.sidspringbackend.Kafka;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record RichMessageRequest (@JsonProperty("email") String email, @JsonProperty("id") String id, @JsonProperty("jobId") String jobId) {
+}

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Model/Job.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Model/Job.java
@@ -2,6 +2,8 @@ package dev.sid.sidspringbackend.Model;
 
 
 import dev.sid.sidspringbackend.POJOs.CandidateRank;
+import dev.sid.sidspringbackend.POJOs.OralTestResults;
+import dev.sid.sidspringbackend.POJOs.TechTestResults;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,7 +25,10 @@ public class Job {
     private String jobTitle;
     private String jobDescription;
 //    private List<String> candidates;
-    private List<CandidateRank> allCandidatesRanking;
+    private List<CandidateRank> allCandidatesRankingPhase1;
+    private List<TechTestResults> allTechTestResults;
+    private List<OralTestResults> allOralTestResults;
+    private int phase;
     private boolean isOpenPosition;
 
     private LocalDateTime jobPostingDate;

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/POJOs/OralTestResults.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/POJOs/OralTestResults.java
@@ -1,0 +1,17 @@
+package dev.sid.sidspringbackend.POJOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OralTestResults {
+    private String senderEmail;
+    private Map<String, String> questions;  // Store dynamic questions with their keys
+    private Map<String, String> answers;
+}

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/POJOs/TechTestResults.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/POJOs/TechTestResults.java
@@ -1,0 +1,19 @@
+package dev.sid.sidspringbackend.POJOs;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TechTestResults {
+    private String senderEmail;
+    private int audioCheatCount;
+    private boolean isCheating;
+    private boolean multipleFacesDetected;
+    private int susSpikeCount;
+    private int testScore;
+    private int totalHeadMovements;
+}

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
@@ -66,7 +66,7 @@ public class JobService {
         Optional<Job> job = findJobByHumanReadableJobId(humanReadableJobId);
 
         job.ifPresent(j -> {
-            j.setAllCandidatesRanking(candidateRankList);
+            j.setAllCandidatesRankingPhase1(candidateRankList);
             jobRepository.save(j);
         });
 

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
@@ -72,4 +72,39 @@ public class JobService {
 
         return job;
     }
+
+
+    public String updateOrCreateOralTestResult(String email, Map<String, String> questions, Map<String, String> answers, String jobId) {
+        // Find the job document by jobId
+        Optional<Job> optionalJob = jobRepository.findByHumanReadableJobId(jobId);
+
+        // Check if job is present
+        if (optionalJob.isEmpty()) {
+            return "Job not found";
+        }
+
+        // Get the job object from the Optional
+        Job job = optionalJob.get();
+
+        // Find existing OralTestResults entry by senderEmail
+        OralTestResults existingResult = job.getAllOralTestResults().stream()
+                .filter(result -> result.getSenderEmail().equals(email))
+                .findFirst()
+                .orElse(null);
+
+        if (existingResult != null) {
+            // Update the existing entry with new questions and answers
+            existingResult.setQuestions(questions);
+            existingResult.setAnswers(answers);
+        } else {
+            // Create new OralTestResults entry and add it to the list
+            OralTestResults newResult = new OralTestResults(email, questions, answers);
+            job.getAllOralTestResults().add(newResult);
+        }
+
+        // Save the updated job document back to the database
+        jobRepository.save(job);
+
+        return "Answers updated successfully";
+    }
 }

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
@@ -2,12 +2,11 @@ package dev.sid.sidspringbackend.Service;
 
 import dev.sid.sidspringbackend.Model.Job;
 import dev.sid.sidspringbackend.POJOs.CandidateRank;
+import dev.sid.sidspringbackend.POJOs.OralTestResults;
 import dev.sid.sidspringbackend.Repository.JobRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 
 @Service
 public class JobService {

--- a/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
+++ b/SidSpringBackend/src/main/java/dev/sid/sidspringbackend/Service/JobService.java
@@ -23,6 +23,8 @@ public class JobService {
         String humanReadableJobId = "JX" + getBase36(5);
         job.setHumanReadableJobId(humanReadableJobId);
         job.setOpenPosition(true);
+        job.setPhase(1);
+        job.setAllOralTestResults(new ArrayList<OralTestResults>());
         return jobRepository.save(job);
     }
 

--- a/new_frontend/src/App.jsx
+++ b/new_frontend/src/App.jsx
@@ -1,8 +1,9 @@
 import "regenerator-runtime";
 import "./App.css"
 import {BrowserRouter as Router, Route, Routes} from "react-router-dom";
-import TestRound1 from "@/TestRound1.jsx";
+import TestRound2 from "@/TestRound2.jsx";
 import CandidateOverview from "@/CandidateOverview.jsx";
+import RichRound2 from "@/RichRound2.jsx";
 
 // const PREPARE_TIME = 1;
 // const ANSWER_TIME = 5;

--- a/new_frontend/src/App.jsx
+++ b/new_frontend/src/App.jsx
@@ -185,7 +185,8 @@ const App = () => {
       <Routes>
 
         <Route path="/admin-dashboard" element={<CandidateOverview />} />
-        <Route path="/round2/:someString" element={<TestRound1 />} />
+        <Route path="/round2/:someString" element={<TestRound2 />} />
+        <Route path="/richRound2/:someString" element={<RichRound2 />} />
 
 
       </Routes>

--- a/new_frontend/src/RichRound2.jsx
+++ b/new_frontend/src/RichRound2.jsx
@@ -1,0 +1,193 @@
+import {CardContent, CardHeader, CardTitle} from "@/components/ui/card.jsx";
+import {useEffect, useState} from "react";
+import SpeechRecognition, {useSpeechRecognition} from "react-speech-recognition";
+import {Input} from "@/components/ui/input.jsx";
+import {Button} from "@/components/ui/button.jsx";
+import {useParams} from "react-router-dom";
+
+
+const PREPARE_TIME = 10;
+const ANSWER_TIME = 10;
+
+const questions = {
+  1: "What is the most important learning from your experience in backend development?",
+  2: "How do you keep yourself up to date with Modern Tech?"
+};
+
+function RichRound2() {
+
+  const [phase, setPhase] = useState('name');
+  const [name, setName] = useState('');
+  const [timer, setTimer] = useState(0);
+  const { someString } = useParams();
+  const [answers, setAnswers] = useState({ 1: '', 2: '' });
+  const { transcript, resetTranscript, browserSupportsSpeechRecognition } = useSpeechRecognition();
+
+  useEffect(() => {
+    let interval;
+    if (timer > 0) {
+      interval = setInterval(() => {
+        setTimer((t) => t - 1);
+      }, 1000);
+    } else if (timer === 0 && (phase === 'prepare1' || phase === 'prepare2' || phase === 'answer1' || phase === 'answer2')) {
+      if (phase === 'answer1' || phase === 'answer2') {
+        const questionNumber = phase === 'answer1' ? 1 : 2;
+        setAnswers((prev) => ({ ...prev, [questionNumber]: transcript }));
+        SpeechRecognition.stopListening();
+      }
+      handleNextPhase();
+    }
+    return () => clearInterval(interval);
+  }, [timer, phase]);
+
+  const handleNextPhase = () => {
+    const phases = {
+      'name': 'instructions',
+      'instructions': 'prepare1',
+      'prepare1': 'answer1',
+      'answer1': 'prepare2',
+      'prepare2': 'answer2',
+      'answer2': 'thank-you'
+    };
+
+    if (phase === 'answer1' || phase === 'answer2') {
+      const questionNumber = phase === 'answer1' ? 1 : 2;
+      setAnswers(prev => {
+        const updatedAnswers = { ...prev, [questionNumber]: transcript };
+        if (phase === 'answer2') {
+          submitResults(updatedAnswers);
+        }
+        return updatedAnswers;
+      });
+      SpeechRecognition.stopListening();
+    }
+
+    const nextPhase = phases[phase];
+    if (nextPhase === 'prepare1' || nextPhase === 'prepare2') {
+      setTimer(PREPARE_TIME);
+      resetTranscript();
+    } else if (nextPhase === 'answer1' || nextPhase === 'answer2') {
+      setTimer(ANSWER_TIME);
+      resetTranscript();
+      SpeechRecognition.startListening({ continuous: true, language: 'en-IN' });
+    }
+
+    setPhase(nextPhase);
+  };
+
+  const submitResults = async (finalAnswers) => {
+
+    try {
+      const response = await fetch('http://localhost:8080/api/v1/rich/update-answers', {
+        method: 'POST',
+        headers : {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          name,
+          questions,
+          answers: finalAnswers,
+          jobId:someString
+        }),
+      });
+      console.log('Interview submitted:', await response.json());
+    } catch (error) {
+      console.error('Error submitting results:', error);
+    }
+  };
+
+  if (!browserSupportsSpeechRecognition) {
+    return (
+      <div className="card-container">
+        <div className="card">
+          <CardContent className="text-center">
+            Your browser doesnt support speech recognition.
+          </CardContent>
+        </div>
+      </div>
+    );
+  }
+
+  const renderPhase = () => {
+    if (phase === 'name') {
+      return (
+        <div className="space-y-4">
+          <Input
+            type="text"
+            placeholder="Enter Email"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="input"
+          />
+          <Button
+            onClick={handleNextPhase}
+            disabled={!name.trim()}
+            className="button"
+          >
+            Continue
+          </Button>
+        </div>
+      );
+    }
+
+    if (phase === 'instructions') {
+      return (
+        <div className="space-y-4">
+          <p className="text-lg">You will be presented with a question and be given 10 seconds to prepare, the next 10 seconds shall be used to answer the question orally.</p>
+          <Button onClick={handleNextPhase} className="button">
+            Start Interview
+          </Button>
+        </div>
+      );
+    }
+
+    if (phase.startsWith('prepare')) {
+      const questionNumber = phase === 'prepare1' ? 1 : 2;
+      return (
+        <div className="space-y-4">
+          <p className="text-lg">Prepare your answer for:</p>
+          <p className="text-xl font-semibold">{questions[questionNumber]}</p>
+          <p className="text-2xl font-bold">Time remaining: {timer}s</p>
+        </div>
+      );
+    }
+
+    if (phase.startsWith('answer')) {
+      const currentQuestion = phase === 'answer1' ? 1 : 2;
+      return (
+        <div className="space-y-4">
+          <p className="text-lg">Now answering:</p>
+          <p className="text-xl font-semibold">{questions[currentQuestion]}</p>
+          <p className="text-2xl font-bold">Time remaining: {timer}s</p>
+          <p className="mt-4 text-green-600">Recording in progress...</p>
+        </div>
+      );
+    }
+
+    if (phase === 'thank-you') {
+      return (
+        <div className="text-center">
+          <h2 className="text-2xl font-bold">Thank You!</h2>
+          <p className="mt-4">Your interview has been submitted successfully.</p>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="card-container">
+      <div className="card">
+        <CardHeader>
+          <CardTitle className="card-title">Interview Session</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {renderPhase()}
+        </CardContent>
+      </div>
+    </div>
+  );
+}
+
+export default RichRound2;

--- a/new_frontend/src/TestRound2.jsx
+++ b/new_frontend/src/TestRound2.jsx
@@ -5,15 +5,15 @@ import {Input} from "@/components/ui/input.jsx";
 import {Button} from "@/components/ui/button.jsx";
 
 
-const PREPARE_TIME = 10;
-const ANSWER_TIME = 10;
+const PREPARE_TIME = 2;
+const ANSWER_TIME = 2;
 
 const questions = {
   1: "What is the most important learning from your experience in backend development?",
   2: "How do you keep yourself up to date with Modern Tech?"
 };
 
-function TestRound1() {
+function TestRound2() {
 
   const [phase, setPhase] = useState('name');
   const [name, setName] = useState('');
@@ -186,4 +186,4 @@ function TestRound1() {
   );
 }
 
-export default TestRound1;
+export default TestRound2;


### PR DESCRIPTION
- Previously results for the oral and technical test were stored as per candidate in Mail.java
- However, this is not feasible due to results being stored Job based rather than candidate based. Hence we now stored the results for each test for every Job document using Lists
- To accommodate this shift, the following has been done

1. For assigning test now, it is compulsory to send jobId as well
2. New Controllers for tests
3. New RichKafkaTemplate and RichMessageRequest
4. New ProducerConfig
5. New POJOs to store List of oral and technical test
6. New consumers to send mail accordingly
7. Test links now contain the jobId, which is passed in the POST request to new endpoint for updating answers